### PR TITLE
Suggested re-write of Proof component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.defaultFormatter": "rome.rome",
     "editor.tabSize": 2
   },
   "eslint.validate": ["javascript"],

--- a/src/components/proofs.js
+++ b/src/components/proofs.js
@@ -1,24 +1,17 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { ethers } from "ethers";
-import { useAccount, useNetwork } from "wagmi";
+import { useAccount, useNetwork, useQuery } from "wagmi";
+import { getCredentials, addProofMetadataItem } from "../utils/secrets";
 import {
-  getCredentials,
-  addProofMetadataItem,
-} from "../utils/secrets";
-import {
-  getDateAsInt,
-  poseidonTwoInputs,
-  proofOfResidency,
-  antiSybil,
+	poseidonTwoInputs,
+	proofOfResidency,
+	antiSybil,
 } from "../utils/proofs";
-import { 
-  serverAddress, 
-  idServerUrl, 
-  holonymAuthMessage, 
-  defaultActionId,
-  chainUsedForLit,
-  defaultChainToProveOn
+import {
+	serverAddress,
+	defaultActionId,
+	defaultChainToProveOn,
 } from "../constants/misc";
 // import residencyStoreABI from "../constants/abi/zk-contracts/ResidencyStore.json";
 // import antiSybilStoreABI from "../constants/abi/zk-contracts/AntiSybilStore.json";
@@ -33,266 +26,379 @@ import { useHoloKeyGenSig } from "../context/HoloKeyGenSig";
 import Relayer from "../utils/relayer";
 import ConnectWalletScreen from "./atoms/connect-wallet-screen";
 
-const ErrorScreen = ({children}) => (
-  <div className="x-container w-container">
-      {children}
-  </div>
-)
-
-
-const LoadingProofsButton = (props) => (
-  <button className="x-button" onClick={props.onClick}>
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-      }}
-    >
-      Proof Loading
-      <Oval
-        height={10}
-        width={10}
-        color="#464646"
-        wrapperStyle={{ marginLeft: "5px" }}
-        wrapperClass=""
-        visible={true}
-        ariaLabel="oval-loading"
-        secondaryColor="#01010c"
-        strokeWidth={2}
-        strokeWidthSecondary={2}
-      />
-    </div>
-  </button>
+const ErrorScreen = ({ children }) => (
+	<div className="x-container w-container">{children}</div>
 );
 
+const LoadingProofsButton = (props) => (
+	<button className="x-button" onClick={props.onClick}>
+		<div
+			style={{
+				display: "flex",
+				justifyContent: "center",
+				alignItems: "center",
+			}}
+		>
+			Proof Loading
+			<Oval
+				height={10}
+				width={10}
+				color="#464646"
+				wrapperStyle={{ marginLeft: "5px" }}
+				wrapperClass=""
+				visible={true}
+				ariaLabel="oval-loading"
+				secondaryColor="#01010c"
+				strokeWidth={2}
+				strokeWidthSecondary={2}
+			/>
+		</div>
+	</button>
+);
+
+async function loadAntiSybil(
+	{ newSecret, serializedCreds },
+	address,
+	actionId,
+) {
+	console.log("actionId", actionId);
+	const footprint = await poseidonTwoInputs([
+		actionId,
+		ethers.BigNumber.from(newSecret).toString(),
+	]);
+
+	const [
+		issuer_,
+		_,
+		countryCode_,
+		nameCitySubdivisionZipStreetHash_,
+		completedAt_,
+		scope,
+	] = serializedCreds;
+
+	return await antiSybil(
+		address,
+		issuer_,
+		actionId,
+		footprint,
+		countryCode_,
+		nameCitySubdivisionZipStreetHash_,
+		completedAt_,
+		scope,
+		newSecret,
+	);
+}
+
+async function loadPoR({ newSecret, serializedCreds }, address) {
+	const salt =
+		"18450029681611047275023442534946896643130395402313725026917000686233641593164"; // this number is poseidon("IsFromUS")
+	const footprint = await poseidonTwoInputs([
+		salt,
+		ethers.BigNumber.from(newSecret).toString(),
+	]);
+
+	const [
+		issuer_,
+		_,
+		countryCode_,
+		nameCitySubdivisionZipStreetHash_,
+		completedAt_,
+		scope,
+	] = serializedCreds;
+	return await proofOfResidency(
+		address,
+		issuer_,
+		salt,
+		footprint,
+		countryCode_,
+		nameCitySubdivisionZipStreetHash_,
+		completedAt_,
+		scope,
+		newSecret,
+	);
+}
+
+async function submitProofThenStoreMetadata(
+	proof,
+	contractName,
+	proofType,
+	actionId,
+	litAuthSig,
+	holoAuthSigDigest,
+	holoKeyGenSigDigest,
+) {
+	const result = await Relayer.prove(
+		proof,
+		contractName,
+		defaultChainToProveOn,
+	);
+	await addProofMetadataItem(
+		result.data,
+		proof.inputs[1],
+		proofType,
+		actionId,
+		litAuthSig,
+		holoAuthSigDigest,
+		holoKeyGenSigDigest,
+	);
+}
+const METAMASK_ERROR_TYPE = "metamask";
+const MINTING_ERROR_TYPE = "mint";
+const NOGOV_ERROR_TYPE = "no-idgov";
+const LOAD_PROOF_TYPE = 'loadProof';
+const SUBMIT_PROOF = 'submitProof';
+
+async function testMetamask(account) {
+	if (account && !window.ethereum) {
+		throw new Error({
+			type: METAMASK_ERROR_TYPE,
+			message: "Currently, this only works with MetaMask",
+		});
+	}
+	// Still have to do this in case metamask isn't logged in. would be good to have equivalent for other types of connectors, but we're not really using wagmi rn
+	try {
+		await window.ethereum.request({ method: "eth_requestAccounts" });
+	} catch (e) {
+		throw new Error({
+			type: METAMASK_ERROR_TYPE,
+			message:
+				"Unable to call eth_requestAccounts. Installing Metamask may fix this bug",
+		});
+	}
+}
 
 const Proofs = () => {
-  const params = useParams();
-  const [creds, setCreds] = useState();
-  const [success, setSuccess] = useState();
-  const [error, setError] = useState();
-  const [customError, setCustomError] = useState();
-  const [proof, setProof] = useState();
-  const [submissionConsent, setSubmissionConsent] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [readyToLoadCreds, setReadyToLoadCreds] = useState();
-  const [es, setES] = useState();
-  const { litAuthSig } = useLitAuthSig();
-  const { data: account } = useAccount();
-  const { switchNetworkAsync } = useNetwork()
-  const { holoAuthSigDigest } = useHoloAuthSig();
-  const { holoKeyGenSigDigest } = useHoloKeyGenSig();
+	const params = useParams();
+	const [creds, setCreds] = useState();
 
-  const proofs = {
-    "us-residency": {
-      name: "US Residency",
-      contractName: "IsUSResident",
-      loadProof: loadPoR,
-    },
-    uniqueness: {
-      name: "Uniqueness",
-      contractName: "SybilResistance",
-      loadProof: loadAntiSybil,
-    },
-  };
+	const [error, setError] = useState();
+	const [customError, setCustomError] = useState();
+	const [proof, setProof] = useState();
+	const [submissionConsent, setSubmissionConsent] = useState(false);
+	const [es, setES] = useState();
+	const { litAuthSig } = useLitAuthSig();
+	const { data: account } = useAccount();
+	const { switchNetworkAsync } = useNetwork();
+	const { holoAuthSigDigest } = useHoloAuthSig();
+	const { holoKeyGenSigDigest } = useHoloKeyGenSig();
+	const accountReadyAddress = useMemo(
+		account?.connector.ready && account?.address && account.address,
+	);
 
-  async function loadPoR() {
-    const creds_ = creds[serverAddress["idgov"]]
-    if (!creds_) {
-      setCustomError(<p>To do this proof, your Holo must have a government ID. Please <a href="/mint/idgov" style={{ color: '#fdc094'}}>add a government ID</a></p>);
-      return;
-    }
-    const salt = "18450029681611047275023442534946896643130395402313725026917000686233641593164"; // this number is poseidon("IsFromUS")
-    const footprint = await poseidonTwoInputs([
-      salt,
-      ethers.BigNumber.from(creds_.newSecret).toString(),
-    ]);
+	const proofs = {
+		"us-residency": {
+			name: "US Residency",
+			contractName: "IsUSResident",
+		},
+		uniqueness: {
+			name: "Uniqueness",
+			contractName: "SybilResistance",
+		},
+	};
 
-    const [issuer_, oldSecret_, countryCode_, nameCitySubdivisionZipStreetHash_, completedAt_, scope] = creds_.serializedCreds;
-    const por = await proofOfResidency(
-      account.address,
-      issuer_,
-      salt,
-      footprint,
-      countryCode_,
-      nameCitySubdivisionZipStreetHash_,
-      completedAt_,
-      scope,
-      creds_.newSecret
-    );
-    // Once setProof is called, the proof is submited
-    setProof(por);
-    console.log("proof is", JSON.stringify(por));
-  }
+	// Steps:
+	// 1. Ensure user's wallet is connected (i.e., get account)
+	// 2. Get & set holoAuthSigDigest and litAuthSig
+	// 3. Get & set creds
+	// 4. Get & set proof
+	// 5. Submit proof tx
 
-  async function loadAntiSybil() {
-    const actionId = params.actionId || defaultActionId;
-    if (!params.actionId)
-      console.error(
-        `Warning: no actionId was given, using default of ${defaultActionId} (generic cross-action sybil resistance)`
-      );
-    console.log("actionId", actionId);
+	const getCredentialsQuery = useQuery(
+		["getCredentials", `${holoKeyGenSigDigest}${holoAuthSigDigest}`],
+		getCredentials(holoKeyGenSigDigest, holoAuthSigDigest, litAuthSig),
+		{
+			onSuccess: (sortedCreds) => {
+				if (sortedCreds) {
+					setCreds(sortedCreds);
+				} else {
+					setError({
+						type: MINTING_ERROR_TYPE,
+						message:
+							"Could not retrieve credentials for proof. Please make sure you have minted your Holo.",
+					});
+				}
+			},
+			onError: (error) => setError({
+        type: MINTING_ERROR_TYPE,
+        message: String(error)
+      }),
+			enabled: accountReadyAddress,
+		},
+	);
 
-    const creds_ = creds[serverAddress["idgov"]]
-    if (!creds_) {
-      setCustomError(<p>To do this proof, your Holo must have a government ID. Please <a href="/mint/idgov" style={{ color: '#fdc094'}}>add a government ID</a></p>);
-      return;
-    }    
-  
-    const footprint = await poseidonTwoInputs([
-      actionId,
-      ethers.BigNumber.from(creds_.newSecret).toString(),
-    ]);
+	const loadProofQuery = useQuery(
+		["loadProof"],
+		async () => {
+			const creds = creds[serverAddress["idgov"]];
+			if (!creds) {
+				throw new Error({
+          type: NOGOV_ERROR_TYPE
+        });
+			}
+			console.log("Loading proof");
+			if (params.proofType === "us-residency") {
+				loadPoR(creds, accountReadyAddress);
+			} else if (params.proofType === "uniqueness") {
+				if (!params.actionId)
+					console.error(
+						`Warning: no actionId was given, using default of ${defaultActionId} (generic cross-action sybil resistance)`,
+					);
+				loadAntiSybil(
+					creds,
+					accountReadyAddress,
+					params.actionId || defaultActionId,
+				);
+			}
+		},
+		{
+			enabled: accountReadyAddress && !!creds && params.proofType in proofs,
+			onError: (error) => {
+				if (type in error && error.type === NOGOV_ERROR_TYPE) {
+					setCustomError(
+						<p>
+							To do this proof, your Holo must have a government ID. Please{" "}
+							<a href="/mint/idgov" style={{ color: "#fdc094" }}>
+								add a government ID
+							</a>
+						</p>,
+					);
+				} else {
+					setError({
+            type: LOAD_PROOF_TYPE,
+            message: String(error)
+          });
+				}
+			},
+			onSuccess: (data) => {
+				setProof(data);
+			},
+		},
+	);
 
-    const [issuer_, oldSecret_, countryCode_, nameCitySubdivisionZipStreetHash_, completedAt_, scope] = creds_.serializedCreds;
+	const submitProofThenStoreMetadataQuery = useQuery(
+		"submitProofThenStoreMetadata",
+		async () =>
+			submitProofThenStoreMetadata(
+				proof,
+				proofs[params.proofType].contractName,
+				params.proofType,
+				params.actionId,
+				litAuthSig,
+				holoAuthSigDigest,
+				holoKeyGenSigDigest,
+			),
+		{
+			enabled: submissionConsent && creds && proof,
+			onSuccess: () => {
+				if (result.error) {
+					console.log("error", result);
+					setError({
+            type: SUBMIT_PROOF,
+            message: result?.error?.response?.data?.error?.reason ||
+            result?.error?.message,
+          });
+					// TODO: At this point, display message to user that they are now signing to store their proof metadata
+				}
+			},
+		},
+	);
 
-    const as = await antiSybil(
-      account.address,
-      issuer_,
-      actionId,
-      footprint,
-      countryCode_, 
-      nameCitySubdivisionZipStreetHash_, 
-      completedAt_, 
-      scope,
-      creds_.newSecret
-    );
-    // Once setProof is called, the proof is submited
-    setProof(as);
-  }
+	useEffect(() => {
+		try {
+			testMetamask(account);
+		} catch (error) {
+			setError(error);
+		}
+	}, [account, window.ethereum]);
 
-  // Steps:
-  // 1. Ensure user's wallet is connected (i.e., get account)
-  // 2. Get & set holoAuthSigDigest and litAuthSig
-  // 3. Get & set creds
-  // 4. Get & set proof
-  // 5. Submit proof tx
+	if (submitProofThenStoreMetadataQuery.isSuccess) {
+		if (params.callback) window.location.href = `https://${params.callback}`;
+		return <Success title="Success" />;
+	}
+	if (error && "type" in error) {
+		if (error.type === METAMASK_ERROR_TYPE) {
+			return (
+				<ErrorScreen>
+					<h3>
+						Please install <a href="https://metamask.io/">Metamask</a>
+					</h3>
+				</ErrorScreen>
+			);
+		}
+    // if (error.type === ) {
 
-  useEffect(() => {
-    if (!account?.address) return;
-    (async () => {
-      setReadyToLoadCreds(true);
-    })()
-  }, [account]);
-
-  useEffect(() => {
-    if (!readyToLoadCreds) return;
-    async function loadCreds() {
-      console.log('Loading creds')
-      const sortedCreds = await getCredentials(holoKeyGenSigDigest, holoAuthSigDigest, litAuthSig);
-      if (sortedCreds) {
-        setCreds(sortedCreds)
-      } else {
-        setError(
-          "Could not retrieve credentials for proof. Please make sure you have minted your Holo."
-        );
-      }
-    }
-    loadCreds();
-  }, [readyToLoadCreds]);
-
-  useEffect(() => {
-    if (!account?.address) return;
-    if (!creds) return;
-    if (!(params.proofType in proofs)) return;
-    console.log('Loading proof')
-    proofs[params.proofType].loadProof();
-  }, [creds]);
-
-  useEffect(() => {
-    if (!(submissionConsent && creds && proof)) return;
-    setSubmitting(true);
-    submitProofThenStoreMetadata(
-      proof,
-      proofs[params.proofType].contractName
-    )
-      .then(() => setSubmitting(false));
-  }, [proof, submissionConsent]);
-
-  if (account && !window.ethereum) {
-    setError("Currently, this only works with MetaMask");
-    return;
-  }
-
-  async function submitProofThenStoreMetadata(proof, contractName) {
-      const result = await Relayer.prove(proof, contractName, defaultChainToProveOn);
-      console.log("relayer result", result)
-      if(!result.error) {
-        // TODO: At this point, display message to user that they are now signing to store their proof metadata
-        await addProofMetadataItem(result.data, proof.inputs[1], params.proofType, params.actionId, litAuthSig, holoAuthSigDigest, holoKeyGenSigDigest);
-        setSuccess(true);
-      }
-      else {
-        console.log("error", result)
-        setError(result?.error?.response?.data?.error?.reason || result?.error?.message)
-      }
-  }
-
-  if (success) {
-    if (params.callback) window.location.href = "https://" + params.callback;
-    return <Success title="Success" />;
-  }
-  // Still have to do this in case metamask isn't logged in. would be good to have equivalent for other types of connectors, but we're not really using wagmi rn
-  try {
-    window.ethereum.request({ method: "eth_requestAccounts" });
-  } catch(e) {
-    console.error("Unable to call eth_requestAccounts. Installing Metamask may fix this bug")
-    return <ErrorScreen>
-            <h3>Please install <a href="https://metamask.io/">Metamask</a></h3>
-          </ErrorScreen>
-  }
-
-  if (customError) return <ErrorScreen>
-        {customError}
-  </ErrorScreen>
-  return (
-    <RoundedWindow>
-    <div style={{display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center"}}>
-        {!account?.address ? (
-          <ConnectWalletScreen />
-        ) : (
-          <>
-            <h2>Prove {proofs[params.proofType].name}</h2>
-                <div className="spacer-med" />
-                <br />
-                {error ? (
-                  <p>Error: {error}</p>
-                ) : (creds ? <p>
-                        This will give you, 
-                        <code> {truncateAddress(account.address)} </code>, 
-                        a <a target="_blank" href="https://cointelegraph.com/news/what-are-soulbound-tokens-sbts-and-how-do-they-work" style={{ color: '#fdc094'}}>soul-bound token</a> (SBT)
-                        showing only this one attribute of you: <code>{proofs[params.proofType].name}</code>. It
-                        may take 5-15 seconds to load.
-                      </p>
-                    :
-                      <p>
-                        &nbsp;Note: You cannot generate proofs before minting a holo. If you have not
-                        already, please <a href="/mint" style={{ color: '#fdc094'}}>mint your holo</a>.
-                      </p>
-                    )
-                  }
-                    <div className="spacer-med" />
-                    <br />
-                    {creds ? (
-                      proof ? (
-                        <button
-                          className="x-button"
-                          onClick={() => setSubmissionConsent(true)}
-                        >
-                          {submitting ? "Submitting..." : "Submit proof"}
-                        </button>
-                      ) : (
-                        <LoadingProofsButton />
-                      )
-                    ) : (
-                      ""
-                    )}
-                  </>
-        )}
-    </div>
-    </RoundedWindow>
-  );
+    // }
+	}
+	if (customError) {
+		return <ErrorScreen>{customError}</ErrorScreen>;
+	}
+	return (
+		<RoundedWindow>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					justifyContent: "center",
+				}}
+			>
+				{!account?.address ? (
+					<ConnectWalletScreen />
+				) : (
+					<>
+						<h2>Prove {proofs[params.proofType].name}</h2>
+						<div className="spacer-med" />
+						<br />
+						{error ? (
+							<p>Error: {error}</p>
+						) : creds ? (
+							<p>
+								This will give you,
+								<code> {truncateAddress(account.address)} </code>, a{" "}
+								<a
+									target="_blank"
+									href="https://cointelegraph.com/news/what-are-soulbound-tokens-sbts-and-how-do-they-work"
+									style={{ color: "#fdc094" }}
+								>
+									soul-bound token
+								</a>{" "}
+								(SBT) showing only this one attribute of you:{" "}
+								<code>{proofs[params.proofType].name}</code>. It may take 5-15
+								seconds to load.
+							</p>
+						) : (
+							<p>
+								&nbsp;Note: You cannot generate proofs before minting a holo. If
+								you have not already, please{" "}
+								<a href="/mint" style={{ color: "#fdc094" }}>
+									mint your holo
+								</a>
+								.
+							</p>
+						)}
+						<div className="spacer-med" />
+						<br />
+						{creds ? (
+							proof ? (
+								<button
+									className="x-button"
+									onClick={() => setSubmissionConsent(true)}
+								>
+									{submitProofThenStoreMetadataQuery.isFetching
+										? "Submitting..."
+										: "Submit proof"}
+								</button>
+							) : (
+								<LoadingProofsButton />
+							)
+						) : (
+							""
+						)}
+					</>
+				)}
+			</div>
+		</RoundedWindow>
+	);
 };
 
 export default Proofs;

--- a/src/utils/relayer.js
+++ b/src/utils/relayer.js
@@ -37,22 +37,8 @@ const Relayer = {
     },
 
     
-    prove : async function(proof, contractName, network, onSuccess, onError) {
-        let res;
-        let error;
-        try {
-          res = await axios.post(`${relayerUrl}/writeProof/${contractName}/${network}`, { writeProofArgs: proof })
-          if (res.status == 200) {
-            onSuccess(res);
-          }
-        } catch (e) {
-            (onError && onError(e))
-            error = e;
-          
-        }
-        return res || {error:error};
-    },
-
+    prove : async (proof, contractName, network, onSuccess, onError) => 
+      axios.post(`${relayerUrl}/writeProof/${contractName}/${network}`, { writeProofArgs: proof }).then(res => res.data),
 
     getTree : async function(network, onError) {
         let res;


### PR DESCRIPTION
Converted explicitly setting derived state into computed state.
Use React Query instead of use Effect for less boiler plate:
1.  React Query allows to you to conditionally enabled or disable execution, a functionality that matches hook last arg.
2. React Query runs a try/catch on your promises. So calling promises does not need to be wrapped with a try catch unless one intends to re-throw mostly for the sake of clarifying the error or formatting the error data. 
3. Although is usually excessive one can use `onError` and `onSuccess` callbacks. However, instead use the error returned by the object that the reactQuery hook returns. 
4. At the moment, because I am not entirely sure about what is the exact UI behavior matching each error, I left things most as are.
5. This PR also suggest using 'Rome' for formatting instead of prettier as it is significantly outperforms prettier and written in rust.